### PR TITLE
Update package to 5.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pythonvirgotools" %}
-{% set version = "5.1.1" %}
+{% set version = "5.1.2" %}
 
 package:
    name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: d425eab31582847ea7add85db3adf8d38253c60fbe500f6ffac0eab3d73ee136
+   sha256: f4a43ea6325c075a1d0992e1e8808d956278e8014107f854991206070476bd47
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

It seems that for some versions of pip when using data_files it will store leap-seconds.list inside into a `PythonVirgoTools-5.1.1.data/data/virgotools/leap-seconds.list` directory rather than the installation directory. This leads to the leap-seconds.list not being found. To make this more consistent package_data is used in the setup.py instead to ensure the leap-seconds.list is stored in the correct directory.