### PR TITLE
Updated pythonvirgotools to version 5.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pythonvirgotools" %}
-{% set version = "5.1.2" %}
+{% set version = "5.1.3" %}
 
 package:
    name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: f4a43ea6325c075a1d0992e1e8808d956278e8014107f854991206070476bd47
+   sha256: 2b4726ea02264a38ae3dd307eda6b49fa80f626ceeec76ebe9b8e0503115e2d7
 
 build:
   number: 0
@@ -26,6 +26,7 @@ requirements:
     - future
     - numpy
     - pytz
+    - tzlocal
 
 test:
   imports:


### PR DESCRIPTION
This new version of pythonvirgotools which includes fixes to the gps
time function and adds configures the test to be ignored when the setup
is not availible e.g. a particular cm server is not avalible

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
